### PR TITLE
Support `constexpr` initialization in C++20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 *.app
 
 bin/
+.idea/
+

--- a/include/crc_cpp.h
+++ b/include/crc_cpp.h
@@ -28,6 +28,15 @@
 #include <cstdint>
 #include <array>
 
+
+//
+// C++20 feature toggle
+//
+#if __cplusplus >= 202002L
+#define CRC_CPP_STD20_MODE 1
+#endif
+
+
 namespace crc_cpp
 {
     // Select the table size to use. This trades speed for size.
@@ -337,7 +346,7 @@ namespace impl
 // If we are C++20 or above, we can leverage cleaner constexpr initialisation
 // otherwise we will attempt to use a static table builder metaprogramming pattern
 // NOTE: Only C++17 will work, other constexpr code prevents C++14 and below working.
-#if __cplusplus >= 202002L
+#ifdef CRC_CPP_STD20_MODE
         [[nodiscard]] static constexpr typename traits::table_type Generate()
         {
             typename traits::table_type table;
@@ -402,17 +411,17 @@ namespace impl
             //
             // Update the accumulator with a new byte
             //
-            void update(uint8_t value) { m_Crc = table_impl::update(m_Crc, value); }
+            constexpr void update(uint8_t value) { m_Crc = table_impl::update(m_Crc, value); }
 
             //
             // Extract the final value of the accumulator.
             //
-            [[nodiscard]] accumulator_type final() { return m_Crc ^ algorithm::xor_out_value; }
+            [[nodiscard]] constexpr accumulator_type final() { return m_Crc ^ algorithm::xor_out_value; }
 
             //
             // Reset the state of the accumulator back to the INITIAL value.
             //
-            void reset() { m_Crc = table_impl::make_initial_value(algorithm::initial_value); }
+            constexpr void reset() { m_Crc = table_impl::make_initial_value(algorithm::initial_value); }
 
 
         private:
@@ -658,11 +667,7 @@ namespace large
     using crc32_d =        family::crc32_d         <table_size::large>;
     using crc32_mpeg2 =    family::crc32_mpeg2     <table_size::large>;
     using crc32_posix =    family::crc32_posix     <table_size::large>;
-    using crc32_q =        family::crc32_q         <table_size::large>;
-    using crc32_jamcrc =   family::crc32_jamcrc    <table_size::large>;
-    using crc32_xfer =     family::crc32_xfer      <table_size::large>;
-
-    using crc64_ecma =     family::crc64_ecma      <table_size::large>;
+    using crc32_q =        family::crc32_q         <table_size::large>; using crc32_jamcrc =   family::crc32_jamcrc    <table_size::large>; using crc32_xfer =     family::crc32_xfer      <table_size::large>; using crc64_ecma =     family::crc64_ecma      <table_size::large>;
 
 }   // namespace large
 
@@ -726,5 +731,9 @@ namespace tiny
 using namespace small;
 
 }   // namespace crc_cpp
+
+#undef CRC_CPP_STD20_MODE
+#undef CRC_CPP_API_CONSTEXPR
+
 
 #endif // CRC_CPP_H_INCLUDED

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -27,6 +27,8 @@
 #include <iomanip>
 #include <string>
 #include <vector>
+#include <array>
+#include <span>
 
 #include "crc_cpp.h"
 
@@ -119,6 +121,27 @@ bool test_crc(
     return result;
 }
 
+//------------------------------------------------------------------------
+// Constexpr test
+//
+// Verify that the CRC can be calculated in a constexpr (compile-time) context
+template<std::size_t N>
+constexpr bool constexpr_check_message(std::array<uint8_t, N> data, uint8_t const expected)
+{
+    crc_cpp::crc8 crc;
+    for(const auto b : data) {
+        crc.update(b);
+    }
+    return expected == crc.final();
+}
+
+constexpr std::array<uint8_t, 9> constexpr_message{'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+[[maybe_unused]] constexpr bool constexpr_test_result = constexpr_check_message(constexpr_message, 0xF4);
+
+static_assert(constexpr_test_result, "Failed to compute crc at compile time");
+//------------------------------------------------------------------------
+
+
 
 int main()
 {
@@ -136,10 +159,10 @@ int main()
 
     // Test vector and result from https://crccalc.com
     // except crc64_ecma which comes from https://etlcppp.com
-    std::vector<uint8_t> message{'1', '2', '3', '4', '5', '6', '7', '8', '9' };
+    std::vector<uint8_t> message{ '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
 
-    // we are exeucting the tests per family (table size set, same algorithm).
+    // we are executing the tests per family (table size set, same algorithm).
     status &=           test_crc<family::crc8>("crc8",           message, 0xF4);
     status &=  test_crc<family::crc8_cdma2000>("crc8_cdma2000",  message, 0xDA);
     status &=      test_crc<family::crc8_darc>("crc8_darc",      message, 0x15);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -28,7 +28,6 @@
 #include <string>
 #include <vector>
 #include <array>
-#include <span>
 
 #include "crc_cpp.h"
 


### PR DESCRIPTION
The `crc` class did not have members marked as `constexpr` and so could
not be used at compile time.

This has been corrected and a test added to static assert in a failure
to generate successfully at compile time.

Fixes #16 