### PR TITLE
Added M17 Link Setup Frame CRC

### DIFF
--- a/include/crc_cpp.h
+++ b/include/crc_cpp.h
@@ -149,7 +149,6 @@ namespace impl
     {
         using traits = crc_traits<TAccumulator, TABLE_SIZE>;
 
-
         [[nodiscard]] static constexpr TAccumulator update_impl_tiny(
                 TAccumulator crc, uint8_t value, typename traits::table_type const &table)
         {
@@ -304,7 +303,7 @@ namespace impl
     //
     // A generic CRC lookup table sized for computing a nibble (4 bits) at a time.
     //
-    // This is can be a large reduction of table space storage for embedded devices.
+    // This is a large reduction of table space storage for embedded devices.
     //
     template <typename TAccumulator,
               TAccumulator const POLYNOMIAL,
@@ -378,8 +377,6 @@ namespace impl
         static constexpr typename traits::table_type m_Table = table_builder<>::table;
 #endif
     };
-
-
 
     //
     // Define the CRC algorithm parameters
@@ -479,8 +476,7 @@ namespace alg
     using crc16_modbus =    impl::crc_algorithm<uint16_t, 0x8005, 0xFFFF, 0x0000, true>;
     using crc16_x25 =       impl::crc_algorithm<uint16_t, 0x1021, 0xFFFF, 0xFFFF, true>;
     using crc16_xmodem =    impl::crc_algorithm<uint16_t, 0x1021, 0x0000, 0x0000, false>;
-
-
+    using crc16_m17lsf =    impl::crc_algorithm<uint16_t, 0x5935, 0xFFFF, 0x0000, false>;
 
     //                                          size,     poly,       init,       xor,        reverse
     using crc32 =           impl::crc_algorithm<uint32_t, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true>;
@@ -548,6 +544,7 @@ namespace family
     template<const table_size TS> class crc16_modbus    : public impl::crc<alg::crc16_modbus, TS>{};
     template<const table_size TS> class crc16_x25       : public impl::crc<alg::crc16_x25, TS>{};
     template<const table_size TS> class crc16_xmodem    : public impl::crc<alg::crc16_xmodem, TS>{};
+    template<const table_size TS> class crc16_m17lsf    : public impl::crc<alg::crc16_m17lsf, TS>{};
 
     template<const table_size TS> class crc32           : public impl::crc<alg::crc32, TS>{};
     template<const table_size TS> class crc32_bzip2     : public impl::crc<alg::crc32_bzip2, TS>{};
@@ -563,7 +560,9 @@ namespace family
 
 } // namespace family
 
-namespace small {
+
+// Default implementation "size" selected using inline namespace
+inline namespace small {
     //------------------------------------------------------------------------
     //
     // Define the set of default CRC implementations using small table size
@@ -606,6 +605,7 @@ namespace small {
     using crc16_modbus =   family::crc16_modbus    <table_size::small>;
     using crc16_x25 =      family::crc16_x25       <table_size::small>;
     using crc16_xmodem =   family::crc16_xmodem    <table_size::small>;
+    using crc16_m17lsf =   family::crc16_m17lsf    <table_size::small>;
 
     using crc32 =          family::crc32           <table_size::small>;
     using crc32_bzip2 =    family::crc32_bzip2     <table_size::small>;
@@ -661,6 +661,7 @@ namespace large
     using crc16_modbus =   family::crc16_modbus    <table_size::large>;
     using crc16_x25 =      family::crc16_x25       <table_size::large>;
     using crc16_xmodem =   family::crc16_xmodem    <table_size::large>;
+    using crc16_m17lsf =   family::crc16_m17lsf    <table_size::large>;
 
     using crc32 =          family::crc32           <table_size::large>;
     using crc32_bzip2 =    family::crc32_bzip2     <table_size::large>;
@@ -713,6 +714,7 @@ namespace tiny
     using crc16_modbus =   family::crc16_modbus    <table_size::tiny>;
     using crc16_x25 =      family::crc16_x25       <table_size::tiny>;
     using crc16_xmodem =   family::crc16_xmodem    <table_size::tiny>;
+    using crc16_m17lsf =   family::crc16_m17lsf    <table_size::tiny>;
 
     using crc32 =          family::crc32           <table_size::tiny>;
     using crc32_bzip2 =    family::crc32_bzip2     <table_size::tiny>;
@@ -727,9 +729,6 @@ namespace tiny
     using crc64_ecma =     family::crc64_ecma      <table_size::tiny>;
 
 }   // namespace tiny
-
-// select the default size
-using namespace small;
 
 }   // namespace crc_cpp
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,12 +5,8 @@ ELSE()
     INCLUDE(${CONAN_CATCH2_ROOT}/lib/cmake/Catch2/Catch.cmake)
 ENDIF()
 
-ADD_LIBRARY(catch_main STATIC catch_main.cpp)
-TARGET_LINK_LIBRARIES(catch_main PUBLIC CONAN_PKG::catch2)
-TARGET_LINK_LIBRARIES(catch_main PRIVATE project_options)
-
 ADD_EXECUTABLE(tests test.cpp)
-TARGET_LINK_LIBRARIES(tests PRIVATE project_warnings project_options catch_main)
+TARGET_LINK_LIBRARIES(tests PRIVATE project_warnings project_options CONAN_PKG::catch2)
 TARGET_INCLUDE_DIRECTORIES(tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 # automatically discover tests that are defined in catch based test files you can modify the unittests. Set TEST_PREFIX

--- a/test/catch_main.cpp
+++ b/test/catch_main.cpp
@@ -1,3 +1,0 @@
-#define CATCH_CONFIG_MAIN  // This tells the catch header to generate a main
-
-#include <catch2/catch_all.hpp>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -105,6 +105,7 @@ TEST_CASE("Algorithm", "TestCRC")
     REQUIRE(test_crc<family::crc8_maxim>(message, 0xA1));
     REQUIRE(test_crc<family::crc8_rohc>(message, 0xD0));
     REQUIRE(test_crc<family::crc8_wcdma>(message, 0x25));
+
     REQUIRE(test_crc<family::crc16_ccit>(message, 0x29B1));
     REQUIRE(test_crc<family::crc16_arc>(message, 0xBB3D));
     REQUIRE(test_crc<family::crc16_augccit>(message, 0xE5CC));
@@ -128,6 +129,8 @@ TEST_CASE("Algorithm", "TestCRC")
     REQUIRE(test_crc<family::crc16_modbus>(message, 0x4B37));
     REQUIRE(test_crc<family::crc16_x25>( message, 0x906E));
     REQUIRE(test_crc<family::crc16_xmodem>( message, 0x31C3));
+    REQUIRE(test_crc<family::crc16_m17lsf>( message, 0x772B));
+
     REQUIRE(test_crc<family::crc32>(message, 0xCBF43926));
     REQUIRE(test_crc<family::crc32_bzip2>( message, 0xFC891918));
     REQUIRE(test_crc<family::crc32_c>(message, 0xE3069283));
@@ -137,5 +140,6 @@ TEST_CASE("Algorithm", "TestCRC")
     REQUIRE(test_crc<family::crc32_q>(message, 0x3010BF7F));
     REQUIRE(test_crc<family::crc32_jamcrc>(message, 0x340BC6D9));
     REQUIRE(test_crc<family::crc32_xfer>(message, 0xBD0BE338));
+
     REQUIRE(test_crc<family::crc64_ecma>( message, 0x6C40DF5F0B497347U));
 }


### PR DESCRIPTION
Added support for M17 LSF CRC from the
[Ham Radio M17 Project](https://m17project.org/)

Cleaned up Catch2 test project, removing unneeded code after moving to v3.