### PR TITLE
Fix Win32 builds

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -97,9 +97,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install conan
         shell: bash
+        # conan 2 is not supported at the moment
         run: |
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install conan
+          python3 -m pip install conan~=1.0
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,11 @@ FIND_PACKAGE(Python COMPONENTS Interpreter REQUIRED)
 
 # install PyPI Python packages using pip
 # Can't update to conan2 yet, not supported by clion or Conan.cmake, so force to 1.x
-EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -m pip install --user --upgrade pip setuptools jinja2 conan~=1.0)
-
+IF(WIN32)
+    EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -m pip install --upgrade pip setuptools jinja2 conan~=1.0)
+ELSE()
+    EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -m pip install --user --upgrade pip setuptools jinja2 conan~=1.0)
+ENDIF()
 # Link this 'library' to set the c++ standard / compile-time options requested
 ADD_LIBRARY(project_options INTERFACE)
 TARGET_COMPILE_FEATURES(project_options INTERFACE cxx_std_${CMAKE_CXX_STANDARD})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,9 @@ FIND_PACKAGE(Python COMPONENTS Interpreter REQUIRED)
 
 # install PyPI Python packages using pip
 # Can't update to conan2 yet, not supported by clion or Conan.cmake, so force to 1.x
-IF(WIN32)
-    EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -m pip install --upgrade pip setuptools jinja2 conan~=1.0)
-ELSE()
-    EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -m pip install --user --upgrade pip setuptools jinja2 conan~=1.0)
-ENDIF()
+# NOTE: also change .github/build_cmake.yml windows build process when fixed.
+EXECUTE_PROCESS(COMMAND ${Python_EXECUTABLE} -m pip install --user --upgrade pip setuptools jinja2 conan~=1.0)
+
 # Link this 'library' to set the c++ standard / compile-time options requested
 ADD_LIBRARY(project_options INTERFACE)
 TARGET_COMPILE_FEATURES(project_options INTERFACE cxx_std_${CMAKE_CXX_STANDARD})


### PR DESCRIPTION
Now that Conan2 is released, the setup we were using automatically updated to it. However the Conan2 package is not supported by the existing conan CMake integration yet and so we need to ensure that we only install a Conan 1.x version.